### PR TITLE
Fix selectDate in CreateNewEvent

### DIFF
--- a/src/components/create-new-event.tsx
+++ b/src/components/create-new-event.tsx
@@ -28,8 +28,8 @@ export const CreateNewEvent = memo(() => {
     }
     const converted = [
       date.getFullYear(),
-      date.getMonth() + 1,
-      date.getDate(),
+      (date.getMonth() + 1).toString().padStart(2, '0'),
+      date.getDate().toString().padStart(2, '0'),
     ].join("-");
     setDateString((str) => `${str ? `${str}\n` : ""}${converted}`);
   };


### PR DESCRIPTION
This PR fixes an issue that the dates are invalid ISO-8601 format if it contains a single digit.