### PR TITLE
NIP-07 リレーへ接続する際のタイムアウト

### DIFF
--- a/src/contexts/ndk-context.tsx
+++ b/src/contexts/ndk-context.tsx
@@ -58,7 +58,7 @@ export const NDKContextProvider = ({ children }: { children: ReactNode }) => {
       explicitRelayUrls: getRelays(),
       signer,
     });
-    await newNDK.connect();
+    await newNDK.connect(1000);
 
     setNDK(newNDK);
 

--- a/src/hooks/use-ndk.ts
+++ b/src/hooks/use-ndk.ts
@@ -39,7 +39,7 @@ export const useNDK = () => {
       signer,
     });
 
-    await newNDK.connect();
+    await newNDK.connect(1000);
 
     setNDK(newNDK);
     setIsLoading(false);
@@ -60,7 +60,7 @@ export const useNDK = () => {
       signer,
     });
 
-    await newNDK.connect();
+    await newNDK.connect(1000);
 
     setNDK(newNDK);
     setIsLoading(false);
@@ -76,7 +76,7 @@ export const useNDK = () => {
     const newNDK = new NDK({
       explicitRelayUrls: getRelays(),
     });
-    await newNDK.connect();
+    await newNDK.connect(1000);
 
     appStorage.setItem("connected", String(false));
 


### PR DESCRIPTION
ログイン時 NIP-07 リレー（の一部）への接続に失敗した際に 10 秒以上待たされることがあるようです。
タイムアウトをとりあえず 1 秒に設定しましたが調整はした方がいいかもしれません。
また、定数に持った方がいいと思いますが作法が分からなかったので直指定しています。